### PR TITLE
画面幅が520pxを切るとヘッダーメニューのスタイルが崩れる問題を修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,12 @@
       .header-menu {
         display: flex;
         justify-content: space-between;
+        list-style: none;
+        padding-left: 0;
+        
+        @media screen and (max-width: 520px) {
+         flex-direction: column; 
+        }
       }
 
       .header-menu li a {


### PR DESCRIPTION
- リンクがめり込むので、flex-directionをcolumnにして縦並びにするようにした。
- フレームワークのデフォルトCSSの仕様でpaddingが入るのを削除
- ulタグのリスト記号を削除（背景が黒なので気づいていなかった)